### PR TITLE
Validate prompts for children before generating images

### DIFF
--- a/cuentos-vivos-sophie/backend/services/aiImageService.js
+++ b/cuentos-vivos-sophie/backend/services/aiImageService.js
@@ -20,10 +20,16 @@ class AIImageService {
   async generateImage(prompt) {
     try {
       console.log('🎨 Generando imagen con DALL-E...');
-      
+
       // Mejorar el prompt para obtener mejores resultados
       const enhancedPrompt = this.enhancePromptForChildren(prompt);
-      
+
+      // Validar que el prompt sea apropiado para niños antes de enviarlo a OpenAI
+      if (!this.validatePromptForChildren(enhancedPrompt)) {
+        console.warn('⚠️ Prompt no apto para niños, usando imagen por defecto');
+        return this.getDefaultImage();
+      }
+
       // Realizar la llamada a DALL-E
       const response = await this.openai.images.generate({
         model: this.model,
@@ -129,7 +135,13 @@ class AIImageService {
   async generateMultipleImages(prompt, count = 2) {
     try {
       const enhancedPrompt = this.enhancePromptForChildren(prompt);
-      
+
+      // Validar que el prompt sea apropiado para niños
+      if (!this.validatePromptForChildren(enhancedPrompt)) {
+        console.warn('⚠️ Prompt no apto para niños, usando imagen por defecto');
+        return [this.getDefaultImage()];
+      }
+
       const response = await this.openai.images.generate({
         model: this.model,
         prompt: enhancedPrompt,


### PR DESCRIPTION
## Summary
- ensure aiImageService validates prompts for children
- fallback to default image if prompt fails validation

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm test` in frontend *(fails to find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68702b2302b08326a0856ee4fbdadcb0