### PR TITLE
Enable real‑time audio narration

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Una aplicación web interactiva que genera cuentos personalizados para Sophie us
 - Interfaz amigable para niños
 - Biblioteca personal de cuentos guardados
 - Experiencia completamente personalizada
+- Narración en tiempo real usando Text-to-Speech
 
 ## 🛠️ Tecnologías
 
@@ -16,6 +17,7 @@ Una aplicación web interactiva que genera cuentos personalizados para Sophie us
 - **Frontend**: React + Vite + Tailwind CSS
 - **IA de Texto**: OpenAI GPT-4 / Google Gemini
 - **IA de Imágenes**: DALL-E 3
+- **IA de Narración**: OpenAI Text-to-Speech
 
 ## 📁 Estructura del Proyecto
 
@@ -45,7 +47,9 @@ Una aplicación web interactiva que genera cuentos personalizados para Sophie us
    cp .env.example .env
    ```
 
-4. Edita el archivo `.env` con tus claves de API
+4. Edita el archivo `.env` con tus claves de API. Necesitarás:
+   - `OPENAI_API_KEY` para texto e imágenes
+   - Opcionalmente activa `ENABLE_TTS=true` para generación de audio y ajusta `TTS_MODEL` y `TTS_VOICE`
 
 5. Inicia el servidor:
    ```bash

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -11,6 +11,12 @@ OPENAI_MODEL=gpt-4
 DALLE_API_KEY=tu_clave_de_dalle_aqui
 DALLE_MODEL=dall-e-3
 
+# Configuración de Text-to-Speech (opcional)
+ENABLE_TTS=false
+# Modelo y voz de OpenAI TTS
+TTS_MODEL=tts-1
+TTS_VOICE=alloy
+
 # Configuración de la Aplicación
 APP_NAME=Cuentos Vivos de Sophie
 APP_VERSION=1.0.0

--- a/backend/controllers/storyController.js
+++ b/backend/controllers/storyController.js
@@ -1,12 +1,14 @@
 // Controlador para manejar las operaciones relacionadas con la generación de historias
 const AITextService = require('../services/aiTextService');
 const AIImageService = require('../services/aiImageService');
+const TTSServices = require('../services/ttsService');
 
 class StoryController {
   constructor() {
     // Inicializar servicios de IA
     this.aiTextService = new AITextService();
     this.aiImageService = new AIImageService();
+    this.ttsService = new TTSServices();
   }
 
   /**
@@ -44,11 +46,20 @@ class StoryController {
       console.log('🖼️ Generando imagen...');
       const imageUrl = await this.aiImageService.generateImage(imagePrompt);
 
-      // Paso 4: Preparar respuesta exitosa
+      // Paso 4: Generar audio usando TTS si se solicita
+      let audioBase64 = null;
+      const withAudio = req.body.withAudio || process.env.ENABLE_TTS === 'true';
+      if (withAudio) {
+        console.log('🔊 Generando narración de audio...');
+        audioBase64 = await this.ttsService.generateSpeech(storyPart);
+      }
+
+      // Paso 5: Preparar respuesta exitosa
       const response = {
         success: true,
         storyPart: storyPart,
         imageUrl: imageUrl,
+        audioBase64,
         metadata: {
           timestamp: new Date().toISOString(),
           wordCount: storyPart.split(' ').length,

--- a/backend/services/ttsService.js
+++ b/backend/services/ttsService.js
@@ -1,0 +1,28 @@
+const OpenAI = require('openai');
+
+class TTSServices {
+  constructor() {
+    this.openai = new OpenAI({
+      apiKey: process.env.OPENAI_API_KEY,
+    });
+    this.model = process.env.TTS_MODEL || 'tts-1';
+    this.voice = process.env.TTS_VOICE || 'alloy';
+  }
+
+  async generateSpeech(text) {
+    try {
+      const response = await this.openai.audio.speech.create({
+        model: this.model,
+        voice: this.voice,
+        input: text,
+      });
+      const buffer = Buffer.from(await response.arrayBuffer());
+      return buffer.toString('base64');
+    } catch (error) {
+      console.error('❌ Error al generar audio con OpenAI:', error);
+      throw new Error('Error al generar audio');
+    }
+  }
+}
+
+module.exports = TTSServices;

--- a/frontend/src/components/StoryDemo.jsx
+++ b/frontend/src/components/StoryDemo.jsx
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import { playBase64Audio } from '../services/audioService'
 
 function StoryDemo() {
   const [story, setStory] = useState('')

--- a/frontend/src/components/StoryGenerator.jsx
+++ b/frontend/src/components/StoryGenerator.jsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import { generateStoryPart } from '../services/storyService'
+import { playBase64Audio } from '../services/audioService'
 
 function StoryGenerator() {
   const [history, setHistory] = useState([])
@@ -16,12 +17,15 @@ function StoryGenerator() {
   const handleGenerate = async () => {
     setLoading(true)
     try {
-      const res = await generateStoryPart(history)
+      const res = await generateStoryPart(history, {}, true)
       if (res.success) {
         const newHistory = [...history, { role: 'assistant', content: res.storyPart }]
         setHistory(newHistory)
         setStory(res.storyPart)
         setImage(res.imageUrl)
+        if (res.audioBase64) {
+          playBase64Audio(res.audioBase64)
+        }
         saveToLibrary(newHistory, res.imageUrl)
       } else {
         setStory(res.error || 'No se pudo generar la historia')

--- a/frontend/src/services/audioService.js
+++ b/frontend/src/services/audioService.js
@@ -1,0 +1,4 @@
+export function playBase64Audio(base64) {
+  const audio = new Audio(`data:audio/mp3;base64,${base64}`)
+  audio.play()
+}

--- a/frontend/src/services/storyService.js
+++ b/frontend/src/services/storyService.js
@@ -1,10 +1,14 @@
 const BASE_URL = '/api'
 
-export async function generateStoryPart(storyHistory = [], userChoices = {}) {
+export async function generateStoryPart(
+  storyHistory = [],
+  userChoices = {},
+  withAudio = true
+) {
   const res = await fetch(`${BASE_URL}/generate-story-part`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ storyHistory, userChoices }),
+    body: JSON.stringify({ storyHistory, userChoices, withAudio }),
   })
   if (!res.ok) {
     throw new Error('Error generating story')


### PR DESCRIPTION
## Summary
- add `ttsService` using OpenAI text-to-speech
- return audio with `/generate-story-part`
- expose TTS options in `.env.example`
- play narration from the frontend using `audioService`
- update README with new feature and setup steps

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6873064b56a08326844e6347c852cdb9