### PR TITLE
Add contributing guidelines for backend tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,9 @@
+# Contribuir
+
+Para ejecutar las pruebas automatizadas del backend sigue estos pasos:
+
+1. `cd backend`
+2. `npm install`
+3. `npm test`
+
+`jest` está listado en `devDependencies`, por lo que es necesario instalar las dependencias antes de poder ejecutar los tests.


### PR DESCRIPTION
## Summary
- add CONTRIBUTING instructions for running backend tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687b4038e254832680999d79d67ab68a