### PR TITLE
Add Render build script

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,14 +81,20 @@ funcionamiento sigue estos pasos:
 
 ### Despliegue en Producción
 
-Para publicar la aplicación (por ejemplo en [Render](https://render.com)) primero genera el frontend y luego inicia el servidor:
+Para publicar la aplicación (por ejemplo en [Render](https://render.com)) puedes usar el script `render-build.sh` incluido en este repositorio. Este script instala las dependencias de **backend** y **frontend** y luego compila la interfaz. Su contenido es:
 
 ```bash
-cd frontend
-npm run build
-cd ../backend
-npm start
+npm install --prefix backend
+npm install --prefix frontend
+npm run build --prefix frontend
 ```
+
+En Render configúralo como comando de _build_ o ejecútalo manualmente. Para iniciar la aplicación en producción usa:
+
+```bash
+npm start --prefix backend
+```
+
 El servidor Express servirá automáticamente los archivos estáticos desde `frontend/dist`.
 
 ## 📝 Estado del Desarrollo

--- a/render-build.sh
+++ b/render-build.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Build script for deploying on Render
+set -e
+
+# Install backend dependencies
+npm install --prefix backend
+
+# Install frontend dependencies
+npm install --prefix frontend
+
+# Build the frontend
+npm run build --prefix frontend


### PR DESCRIPTION
## Summary
- add `render-build.sh` for Render deployments
- document build steps and start command in the README

## Testing
- `npm install --prefix backend`
- `CI=true npm test --prefix backend`


------
https://chatgpt.com/codex/tasks/task_e_687b403872c883268bb5b70f973c2364